### PR TITLE
Update AWS region in main.tf to EU-West-1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 provider "aws" {
   version = "2.56.0"
   alias   = "us"
-  region  = "us-east-1"
+  region  = "eu-west-1"
   profile = var.profile
 }
 
@@ -32,7 +32,7 @@ provider "aws" {
 provider "aws" {
   version = "2.56.0"
   alias   = "root-us"
-  region  = "us-east-1"
+  region  = "eu-west-1"
   profile = var.root_profile
 }
 


### PR DESCRIPTION
As shown in the network map, we're led to believe things are running in an EU AZ: https://raw.githubusercontent.com/HSEIreland/covid-tracker-infra/master/docs/CovidTrackerIreland-Network.png

Do we know why a US AZ is specified here?